### PR TITLE
Fix compilation and linting errors

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -117,7 +117,7 @@ fn main() -> Result<(), BuildError> {
 
         if markdown.ends_with(".md") {
             match Command::new("pandoc")
-                .args(&["--standalone", "--to", "man", markdown, "-o", manpage])
+                .args(["--standalone", "--to", "man", markdown, "-o", manpage])
                 .status()
             {
                 Ok(status) => {

--- a/cli/src/action/command.rs
+++ b/cli/src/action/command.rs
@@ -152,7 +152,7 @@ impl Action for CommandSetStateAction {
 
         // send batch to target
         Client::new()
-            .post(&format!("{}/batches", target))
+            .post(format!("{}/batches", target))
             .header(header::CONTENT_TYPE, "octet-stream")
             .header("Authorization", auth)
             .body(batch_bytes)
@@ -298,7 +298,7 @@ impl Action for CommandGetStateAction {
 
         // send batch to target
         Client::new()
-            .post(&format!("{}/batches", target))
+            .post(format!("{}/batches", target))
             .header(header::CONTENT_TYPE, "octet-stream")
             .header("Authorization", auth)
             .body(batch_bytes)
@@ -348,7 +348,7 @@ impl Action for CommandShowStateAction {
             .ok_or_else(|| CliError::ActionError("'address' is required".into()))?;
 
         Client::new()
-            .get(&format!("{}/state/{}", target, address))
+            .get(format!("{}/state/{}", target, address))
             .header("Authorization", auth)
             .send()
             .map_err(|err| {

--- a/cli/src/action/command.rs
+++ b/cli/src/action/command.rs
@@ -32,7 +32,7 @@ use super::{create_cylinder_jwt_auth_signer_key, Action};
 pub struct CommandSetStateAction;
 
 impl Action for CommandSetStateAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run(&mut self, arg_matches: Option<&ArgMatches>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
         let (auth, signer) = create_cylinder_jwt_auth_signer_key(args.value_of("key"))?;
@@ -188,7 +188,7 @@ impl Action for CommandSetStateAction {
 pub struct CommandGetStateAction;
 
 impl Action for CommandGetStateAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run(&mut self, arg_matches: Option<&ArgMatches>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
         let (auth, signer) = create_cylinder_jwt_auth_signer_key(args.value_of("key"))?;
@@ -334,7 +334,7 @@ impl Action for CommandGetStateAction {
 pub struct CommandShowStateAction;
 
 impl Action for CommandShowStateAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run(&mut self, arg_matches: Option<&ArgMatches>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
         let (auth, _) = create_cylinder_jwt_auth_signer_key(args.value_of("key"))?;

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -51,7 +51,7 @@ const DEFAULT_LOG_TIME_SECS: u32 = 30; // time in seconds
 /// An Action is a single subcommand for CLI operations.
 pub trait Action {
     /// Run a CLI Action with the given args
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError>;
+    fn run(&mut self, arg_matches: Option<&ArgMatches>) -> Result<(), CliError>;
 }
 
 /// A collection of Subcommands associated with a single parent command.
@@ -82,7 +82,7 @@ impl<'a> SubcommandActions<'a> {
 }
 
 impl<'s> Action for SubcommandActions<'s> {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run(&mut self, arg_matches: Option<&ArgMatches>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
         let (subcommand, args) = args.subcommand();

--- a/cli/src/action/playlist.rs
+++ b/cli/src/action/playlist.rs
@@ -236,7 +236,7 @@ impl Action for SubmitPlaylistAction {
             .value_of("input")
             .ok_or_else(|| CliError::ActionError("'input' is required".into()))?;
 
-        let mut in_file = File::open(&input)
+        let mut in_file = File::open(input)
             .map_err(|_| CliError::ActionError("Unable to open input file".to_string()))?;
 
         info!(

--- a/cli/src/action/playlist.rs
+++ b/cli/src/action/playlist.rs
@@ -44,7 +44,7 @@ const DEFAULT_RATE: &str = "1/s";
 pub struct CreatePlaylistAction;
 
 impl Action for CreatePlaylistAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run(&mut self, arg_matches: Option<&ArgMatches>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
         let mut output_writer: Box<dyn Write> = match args.value_of("output") {
@@ -117,7 +117,7 @@ impl Action for CreatePlaylistAction {
 pub struct ProcessPlaylistAction;
 
 impl Action for ProcessPlaylistAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run(&mut self, arg_matches: Option<&ArgMatches>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
         let mut in_file = File::open(
@@ -162,7 +162,7 @@ impl Action for ProcessPlaylistAction {
 pub struct BatchPlaylistAction;
 
 impl Action for BatchPlaylistAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run(&mut self, arg_matches: Option<&ArgMatches>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
         let max_txns: usize = args
@@ -207,7 +207,7 @@ impl Action for BatchPlaylistAction {
 pub struct SubmitPlaylistAction;
 
 impl Action for SubmitPlaylistAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run(&mut self, arg_matches: Option<&ArgMatches>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
         let (auth, _) = create_cylinder_jwt_auth_signer_key(args.value_of("key"))?;

--- a/cli/src/action/workload.rs
+++ b/cli/src/action/workload.rs
@@ -57,7 +57,7 @@ impl Action for WorkloadAction {
             if rate.contains('-') {
                 let split_rate: Vec<String> = rate.split('-').map(String::from).collect();
                 let min_string = split_rate
-                    .get(0)
+                    .first()
                     .ok_or_else(|| CliError::ActionError("Min target rate not provided".into()))?;
                 let max_string = split_rate
                     .get(1)

--- a/cli/src/action/workload.rs
+++ b/cli/src/action/workload.rs
@@ -36,7 +36,7 @@ use super::{create_cylinder_jwt_auth_signer_key, Action, DEFAULT_LOG_TIME_SECS};
 pub struct WorkloadAction;
 
 impl Action for WorkloadAction {
-    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+    fn run(&mut self, arg_matches: Option<&ArgMatches>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
         let (auth, signer) = create_cylinder_jwt_auth_signer_key(args.value_of("key"))?;

--- a/examples/simple_xo/src/main.rs
+++ b/examples/simple_xo/src/main.rs
@@ -215,7 +215,7 @@ fn create_executor(context_manager: &ContextManager) -> Executor {
 fn create_batch(signer: &dyn Signer, game_name: &str, payload: &str) -> BatchPair {
     let mut sha = Sha512::default();
     sha.update(game_name);
-    let game_address = "5b7349".to_owned() + &hex::encode(&sha.finalize())[..64];
+    let game_address = "5b7349".to_owned() + &hex::encode(sha.finalize())[..64];
     let txn_pair = TransactionBuilder::new()
         .with_family_name("xo".to_string())
         .with_family_version("1.0".to_string())

--- a/libtransact/build.rs
+++ b/libtransact/build.rs
@@ -34,8 +34,8 @@ fn main() {
 
     // Run protoc
     protoc_rust::Codegen::new()
-        .out_dir(&dest_path.to_str().unwrap())
-        .inputs(&[
+        .out_dir(dest_path.to_str().unwrap())
+        .inputs([
             proto_path.join("batch.proto").to_str().unwrap(),
             proto_path.join("transaction.proto").to_str().unwrap(),
             proto_path.join("events.proto").to_str().unwrap(),
@@ -59,7 +59,7 @@ fn main() {
             #[cfg(feature = "key-value-state")]
             proto_path.join("key_value_state.proto").to_str().unwrap(),
         ])
-        .includes(&[proto_path.to_str().unwrap()])
+        .includes([proto_path.to_str().unwrap()])
         .customize(Customize::default())
         .run()
         .expect("Protoc Error");

--- a/libtransact/src/contract/context/key_value.rs
+++ b/libtransact/src/contract/context/key_value.rs
@@ -90,11 +90,7 @@ where
         &self,
         key: &K,
     ) -> Result<Option<HashMap<String, ValueType>>, ContractContextError> {
-        Ok(self
-            .get_state_entries(vec![key])?
-            .into_iter()
-            .map(|(_, val)| val)
-            .next())
+        Ok(self.get_state_entries(vec![key])?.into_values().next())
     }
 
     /// Attempts to unset the data in state at the address calculated from the provided natural key.

--- a/libtransact/src/families/sabre/addressing.rs
+++ b/libtransact/src/families/sabre/addressing.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Write;
+
 use sha2::{Digest, Sha512};
 
 use crate::handler::ApplyError;
@@ -28,8 +30,10 @@ const CONTRACT_PREFIX: &str = "00ec02";
 pub fn hash(to_hash: &str, num: usize) -> Result<String, ApplyError> {
     let temp = Sha512::digest(to_hash)
         .iter()
-        .map(|b| format!("{:02x}", b))
-        .collect::<String>();
+        .fold(String::new(), |mut output, b| {
+            let _ = write!(output, "{:02x}", b);
+            output
+        });
     let hash = match temp.get(..num) {
         Some(x) => x,
         None => {

--- a/libtransact/src/families/sabre/handler.rs
+++ b/libtransact/src/families/sabre/handler.rs
@@ -14,6 +14,8 @@
 
 //! Provides a Sawtooth Transaction Handler for executing Sabre transactions.
 
+use std::fmt::Write;
+
 use sha2::{Digest, Sha512};
 
 use crate::handler::{ApplyError, TransactionContext, TransactionHandler};
@@ -240,10 +242,13 @@ fn create_contract(
 
     state.set_contract(name, version, contract)?;
 
-    let contract_sha512 = Sha512::digest(payload.contract())
-        .iter()
-        .map(|b| format!("{:02x}", b))
-        .collect::<String>();
+    let contract_sha512 =
+        Sha512::digest(payload.contract())
+            .iter()
+            .fold(String::new(), |mut output, b| {
+                let _ = write!(output, "{:02x}", b);
+                output
+            });
 
     let contract_registry_version = VersionBuilder::new()
         .with_version(version.into())

--- a/libtransact/src/families/smallbank/handler.rs
+++ b/libtransact/src/families/smallbank/handler.rs
@@ -334,11 +334,11 @@ fn save_account(account: &Account, context: &mut dyn TransactionContext) -> Resu
 fn get_smallbank_prefix() -> String {
     let mut sha = Sha512::new();
     sha.update("smallbank");
-    hex::encode(&sha.finalize())[..6].to_string()
+    hex::encode(sha.finalize())[..6].to_string()
 }
 
 fn create_smallbank_address(payload: &str) -> String {
     let mut sha = Sha512::new();
     sha.update(payload.as_bytes());
-    get_smallbank_prefix() + &hex::encode(&sha.finalize())[..64]
+    get_smallbank_prefix() + &hex::encode(sha.finalize())[..64]
 }

--- a/libtransact/src/families/smallbank/workload/playlist.rs
+++ b/libtransact/src/families/smallbank/workload/playlist.rs
@@ -593,7 +593,7 @@ impl<'a> FmtWriter<'a> {
 impl<'a> fmt::Write for FmtWriter<'a> {
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
         let w = &mut *self.writer;
-        w.write_all(s.as_bytes()).map_err(|_| fmt::Error::default())
+        w.write_all(s.as_bytes()).map_err(|_| fmt::Error)
     }
 }
 

--- a/libtransact/src/sawtooth.rs
+++ b/libtransact/src/sawtooth.rs
@@ -201,12 +201,12 @@ fn as_sawtooth_header(header: &TransactionHeader) -> SawtoothTxnHeader {
 
     sawtooth_header.set_family_name(header.family_name().to_owned());
     sawtooth_header.set_family_version(header.family_version().to_owned());
-    sawtooth_header.set_signer_public_key(hex::encode(&header.signer_public_key()));
-    sawtooth_header.set_batcher_public_key(hex::encode(&header.batcher_public_key()));
+    sawtooth_header.set_signer_public_key(hex::encode(header.signer_public_key()));
+    sawtooth_header.set_batcher_public_key(hex::encode(header.batcher_public_key()));
     sawtooth_header.set_dependencies(header.dependencies().into());
     sawtooth_header.set_inputs(header.inputs().iter().map(hex::encode).collect());
     sawtooth_header.set_outputs(header.outputs().iter().map(hex::encode).collect());
-    sawtooth_header.set_nonce(hex::encode(&header.nonce()));
+    sawtooth_header.set_nonce(hex::encode(header.nonce()));
 
     sawtooth_header
 }

--- a/libtransact/src/state/merkle/kv/mod.rs
+++ b/libtransact/src/state/merkle/kv/mod.rs
@@ -476,7 +476,7 @@ impl MerkleRadixTree {
         // We expect this to be hex, since we generated it
         let root_hash_bytes = ::hex::decode(&self.root_hash).expect("Improper hex");
 
-        for &(ref key, ref value) in batch {
+        for (key, value) in batch {
             match db_writer.put(::hex::encode(key).as_bytes(), value) {
                 Ok(_) => continue,
                 Err(DatabaseError::DuplicateEntry) => {
@@ -499,7 +499,7 @@ impl MerkleRadixTree {
             parent: root_hash_bytes.clone(),
             additions: batch
                 .iter()
-                .map(|&(ref hash, _)| hash.clone())
+                .map(|(hash, _)| hash.clone())
                 .collect::<Vec<Vec<u8>>>(),
             successors: vec![],
         };

--- a/libtransact/src/state/merkle/sql/backend/postgres.rs
+++ b/libtransact/src/state/merkle/sql/backend/postgres.rs
@@ -36,7 +36,7 @@ impl Connection for PostgresConnection {
     type ConnectionType = diesel::pg::PgConnection;
 
     fn as_inner(&self) -> &Self::ConnectionType {
-        &*self.0
+        &self.0
     }
 }
 

--- a/libtransact/src/state/merkle/sql/backend/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/backend/sqlite.rs
@@ -45,7 +45,7 @@ impl Connection for SqliteConnection {
     type ConnectionType = sqlite::SqliteConnection;
 
     fn as_inner(&self) -> &Self::ConnectionType {
-        &*self.0
+        &self.0
     }
 }
 

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -155,7 +155,7 @@ impl<B: Backend> SqlMerkleState<B> {
     pub fn initial_state_root_hash(&self) -> Result<String, InternalError> {
         let (hash, _) = encode_and_hash(Node::default())?;
 
-        Ok(hex::encode(&hash))
+        Ok(hex::encode(hash))
     }
 }
 

--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -96,7 +96,7 @@ where
 
     let (initial_state_root_hash, _) = encode_and_hash(Node::default())?;
     let tree_id: i64 = if builder.create_tree {
-        store.get_or_create_tree(&tree_name, &hex::encode(&initial_state_root_hash))?
+        store.get_or_create_tree(&tree_name, &hex::encode(initial_state_root_hash))?
     } else {
         store.get_tree_id_by_name(&tree_name)?.ok_or_else(|| {
             InvalidStateError::with_message("must provide the name of an existing tree".into())

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -94,7 +94,7 @@ where
 
     let (initial_state_root_hash, _) = encode_and_hash(Node::default())?;
     let tree_id: i64 = if builder.create_tree {
-        store.get_or_create_tree(&tree_name, &hex::encode(&initial_state_root_hash))?
+        store.get_or_create_tree(&tree_name, &hex::encode(initial_state_root_hash))?
     } else {
         store.get_tree_id_by_name(&tree_name)?.ok_or_else(|| {
             InvalidStateError::with_message("must provide the name of an existing tree".into())

--- a/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
@@ -202,9 +202,7 @@ where
         .load::<MerkleRadixChangeLogDeletion>(conn)?
         .into_iter()
         .fold(HashMap::new(), |mut acc, successor| {
-            let hashes = acc
-                .entry(successor.successor_state_root)
-                .or_insert_with(Vec::new);
+            let hashes: &mut Vec<_> = acc.entry(successor.successor_state_root).or_default();
             hashes.push(successor.deletion);
             acc
         });

--- a/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
@@ -183,7 +183,7 @@ where
     }
 
     let parent = addition_changelog
-        .get(0)
+        .first()
         .and_then(|entry| entry.parent_state_root.clone());
 
     let change_additions = addition_changelog

--- a/libtransact/src/workload/batch_gen.rs
+++ b/libtransact/src/workload/batch_gen.rs
@@ -150,7 +150,7 @@ impl<'a> Iterator for BatchListFeeder<'a> {
             Err(err) => return Some(Err(BatchingError::InternalError(err))),
         };
 
-        batches.get(0).map(|b| Ok(b.clone()))
+        batches.first().map(|b| Ok(b.clone()))
     }
 }
 

--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -648,7 +648,7 @@ fn submit_batch(
     batch_bytes: Vec<u8>,
 ) -> Result<String, WorkloadRunnerError> {
     Client::new()
-        .post(&format!("{}/batches", target))
+        .post(format!("{}/batches", target))
         .header(header::CONTENT_TYPE, "octet-stream")
         .header("Authorization", auth)
         .body(batch_bytes)

--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -144,8 +144,8 @@ impl WorkloadRunner {
         WorkerShutdownSignaler {
             senders: self
                 .workloads
-                .iter()
-                .map(|(_, worker)| (worker.id.clone(), worker.sender.clone()))
+                .values()
+                .map(|worker| (worker.id.clone(), worker.sender.clone()))
                 .collect(),
         }
     }

--- a/libtransact/tests/state/merkle/mod.rs
+++ b/libtransact/tests/state/merkle/mod.rs
@@ -335,7 +335,7 @@ where
             key: key_hash.to_string(),
             value: "2.0".as_bytes().to_vec(),
         });
-        values.insert(key_hash.clone().to_string(), "2.0".to_string());
+        values.insert(key_hash.to_string(), "2.0".to_string());
     }
 
     // The first item below(e55420...89b9) shares a common prefix
@@ -451,10 +451,10 @@ fn test_merkle_trie_update_same_address_space_with_no_children<M>(
     // Perform some updates on the lower keys
     for &(_, ref key_hash) in key_hash_to_be_inserted.iter() {
         state_changes.push(StateChange::Set {
-            key: key_hash.clone().to_string(),
+            key: key_hash.to_string(),
             value: "2.0".as_bytes().to_vec(),
         });
-        values.insert(key_hash.clone().to_string(), "2.0".to_string());
+        values.insert(key_hash.to_string(), "2.0".to_string());
     }
 
     // The first item below(e55420...89b9) shares a common prefix


### PR DESCRIPTION
The clones removed were cloning a &str prior to calling to_string(), which is not necessary. Also fixes clippy lints.